### PR TITLE
Added beautiful exception for laravel

### DIFF
--- a/src/Exceptions/LaravelOdooException.php
+++ b/src/Exceptions/LaravelOdooException.php
@@ -1,0 +1,10 @@
+<?php
+namespace Obuchmann\OdooJsonRpc\Exceptions;
+use Exception;
+class LaravelOdooException extends Exception
+{   
+    public function render($request)
+    {       
+        return response()->json(["success" => false, "message" => $this->getMessage() ]);       
+    }
+}

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -6,6 +6,7 @@ namespace Obuchmann\OdooJsonRpc\JsonRpc;
 
 use GuzzleHttp\Exception\GuzzleException;
 use Obuchmann\OdooJsonRpc\Exceptions\OdooException;
+use Obuchmann\OdooJsonRpc\Exceptions\LaravelOdooException;
 use Psr\Http\Message\ResponseInterface;
 
 class Client
@@ -45,6 +46,7 @@ class Client
         }
         $this->lastResponse = $response;
 
+        
         return match($response->getStatusCode()) {
             200 => $this->makeResponse($response), // TODO ->result kann auch nicht definiert sein. Normal wenn ->error gegeben ist.
             default => throw new OdooException($response)
@@ -67,7 +69,8 @@ class Client
             if(isset($json->error->data) && isset($json->error->data->message)){
                 $message .= ': '.$json->error->data->message;
             }
-            throw new OdooException($response, $message, $json->error->code ?? null);
+
+            throw new LaravelOdooException($message ?? null);
         }
         return $json->result;
     }


### PR DESCRIPTION
I was having troubles trying to show errors on the API because all is managed inside the library. So i created a new Laravel Exception to handle that message and be able to catch it through an api response.

So now the exception response will be like this:
![image](https://user-images.githubusercontent.com/32471957/209886122-eac6a405-0f47-4e83-b22e-31aea50f7012.png)
