### PR TITLE
[Config] Add guzzle ssl verify config

### DIFF
--- a/config/odoo.php
+++ b/config/odoo.php
@@ -34,5 +34,12 @@ return [
         'lang' => env('ODOO_LANG', null),
         'timezone' => env('ODOO_TIMEZONE', null),
         'companyId' => env('ODOO_COMPANY_ID', null),
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Use SSL Verify
+    |--------------------------------------------------------------------------
+    */
+    'ssl_verify' => (bool) env('ODOO_SSL_VERIFY', true)
 ];

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -13,7 +13,7 @@ class Client
     private \GuzzleHttp\Client $client;
     private ?ResponseInterface $lastResponse = null;
 
-    public function __construct(string $baseUri, private string $service = 'object')
+    public function __construct(string $baseUri, private string $service = 'object', $sslVerify = true)
     {
 
         $this->client = new \GuzzleHttp\Client([
@@ -21,7 +21,7 @@ class Client
                 'Content-Type' => 'application/json',
             ],
             'base_uri' => $baseUri,
-            'verify' => config('odoo.ssl_verify',true),
+            'verify' => $sslVerify,
         ]);
 
     }

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -21,6 +21,7 @@ class Client
                 'Content-Type' => 'application/json',
             ],
             'base_uri' => $baseUri,
+            'verify' => config('odoo.ssl_verify',true),
         ]);
 
     }

--- a/src/Odoo/Config.php
+++ b/src/Odoo/Config.php
@@ -13,7 +13,8 @@ class Config
         protected string $database,
         protected string $host,
         protected string $username,
-        protected string $password)
+        protected string $password,
+        protected bool $sslVerify)
     {
 
     }
@@ -50,7 +51,13 @@ class Config
         return $this->password;
     }
 
-
+    /**
+     * @return boolean
+     */
+    public function getSslVerify(): string
+    {
+        return $this->sslVerify;
+    }
 
 
 }

--- a/src/Odoo/Endpoint/Endpoint.php
+++ b/src/Odoo/Endpoint/Endpoint.php
@@ -25,7 +25,7 @@ class Endpoint
     public function getClient(bool $fresh = false): Client
     {
         if ($fresh || null == $this->client) {
-            $this->client = new Client($this->getConfig()->getHost(), $this->service);
+            $this->client = new Client($this->getConfig()->getHost(), $this->service, $this->getConfig()->getSslVerify());
         }
         return $this->client;
     }

--- a/src/OdooServiceProvider.php
+++ b/src/OdooServiceProvider.php
@@ -42,6 +42,7 @@ class OdooServiceProvider extends ServiceProvider
                 host: config('odoo.host', ''),
                 username: config('odoo.username', ''),
                 password: config('odoo.password', ''),
+                sslVerify: config('odoo.ssl_verify',true)
             ), new Context(
                 lang: config('odoo.context.lang'),
                 timezone: config('odoo.context.timezone'),


### PR DESCRIPTION
Hello,

I've added a configuration for Guzzle SSL verification. Sometimes, issues arise on the development server when it doesn't use a valid SSL, leading to a GuzzleHttp Exception with cURL error 60: SSL certificate problem.

With this addition, we can disable Guzzle verification through the .env file or config.php

Thanks

to enable Guzzle SSL verify (its default to true)
```env
ODOO_SSL_VERIFY=true
```

to disable Guzzle SSL verify
```env
ODOO_SSL_VERIFY=false
```