### PR TITLE
Fix typo in comment

### DIFF
--- a/src/Odoo/OdooModel.php
+++ b/src/Odoo/OdooModel.php
@@ -52,7 +52,7 @@ class OdooModel
 
     public static function query()
     {
-        //TODO: Lazy evaluate fields only for queries that needs feelds :low
+        //TODO: Lazy evaluate fields only for queries that needs fields :low
         return new Odoo\Models\ModelQuery(static::newInstance(), self::$odoo->model(static::model())->fields(static::fieldNames()));
     }
 


### PR DESCRIPTION
## Summary
- fix a typo in `OdooModel` comment

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fc2772648832183111a68b970d01a