### PR TITLE
I've made some adjustments to ensure compatibility with Odoo 17 for s…

### DIFF
--- a/src/Odoo/Endpoint/ObjectEndpoint.php
+++ b/src/Odoo/Endpoint/ObjectEndpoint.php
@@ -77,13 +77,9 @@ class ObjectEndpoint extends Endpoint
 
     public function count(string $model, ?Domain $domain = null, int $offset = 0, ?int $limit = null, ?string $order = null, ?Options $options = null): int
     {
-        return $this->execute(new Search(
+        return $this->execute(new \Obuchmann\OdooJsonRpc\Odoo\Request\SearchCount(
             model: $model,
-            domain: $domain ?? new Domain(),
-            offset: $offset,
-            limit: $limit,
-            order: $order,
-            count: true
+            domain: $domain ?? new Domain()
         ), $options);
     }
 

--- a/src/Odoo/Request/Search.php
+++ b/src/Odoo/Request/Search.php
@@ -21,7 +21,7 @@ class Search extends Request
      * @param int $offset
      * @param int|null $limit
      * @param string|null $order
-     * @param bool|null $count
+     * @param bool $count // Changed default to false
      */
     public function __construct(
         string $model,
@@ -29,20 +29,26 @@ class Search extends Request
         protected int $offset = 0,
         protected ?int $limit = null,
         protected ?string $order = null,
-        protected ?bool $count = null,
+        protected bool $count = false, // Changed default to false
     )
     {
-        parent::__construct( $model, 'search');
+        parent::__construct( $model, $count ? 'search_count' : 'search'); // Dynamically set method
     }
 
     public function toArray(): array
     {
+        if ($this->count) {
+            return [
+                $this->domain->toArray(),
+            ];
+        }
+
         return [
             $this->domain->toArray(),
             $this->offset,
             $this->limit,
             $this->order,
-            $this->count
+            // $this->count is no longer sent as a parameter for 'search'
         ];
     }
 }

--- a/src/Odoo/Request/SearchCount.php
+++ b/src/Odoo/Request/SearchCount.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Obuchmann\OdooJsonRpc\Odoo\Request;
+
+use Obuchmann\OdooJsonRpc\Odoo\Request\Arguments\Domain;
+
+class SearchCount extends Request
+{
+    public function __construct(
+        string $model,
+        protected Domain $domain
+    )
+    {
+        parent::__construct( $model, 'search_count');
+    }
+
+    public function toArray(): array
+    {
+        return [
+            $this->domain->toArray(),
+        ];
+    }
+}


### PR DESCRIPTION
…earch and count methods.

Here's a summary of what I did:

This addresses an incompatibility with Odoo 17 where the 'search' method no longer accepts the 'count' parameter.

Changes include:

1.  I introduced a new `SearchCount` request class (`src/Odoo/Request/SearchCount.php`) that uses the `search_count` RPC method with only the domain as a parameter.
2.  I modified the `Search` request class (`src/Odoo/Request/Search.php`):
    *   If the `count` parameter is true, it now uses the `search_count` RPC method and sends only the domain, similar to `SearchCount`.
    *   If the `count` parameter is false (default for a normal search), it uses the `search` RPC method and sends the domain, offset, limit, and order parameters. Crucially, it no longer sends the boolean `count` value itself as an argument to the `search` method's payload, resolving the "BaseModel.search() takes from 2 to 5 positional arguments but 6 were given" error on Odoo 17.
3.  I updated the `count()` method in `src/Odoo/Endpoint/ObjectEndpoint.php` to use the new `SearchCount` request class.

These changes ensure that your search and count operations are compatible with Odoo 17's API.