### PR TITLE
fix(dehydration): prevent foreign key array data from causing Odoo en…

### DIFF
--- a/tests/HydrationBugFixTest.php
+++ b/tests/HydrationBugFixTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Obuchmann\OdooJsonRpc\Tests;
+
+use Obuchmann\OdooJsonRpc\Attributes\BelongsTo;
+use Obuchmann\OdooJsonRpc\Attributes\Field;
+use Obuchmann\OdooJsonRpc\Attributes\HasMany;
+use Obuchmann\OdooJsonRpc\Attributes\Key;
+use Obuchmann\OdooJsonRpc\Attributes\Model;
+use Obuchmann\OdooJsonRpc\Odoo\Mapping\LazyHasMany;
+use Obuchmann\OdooJsonRpc\Odoo\OdooModel;
+use stdClass;
+
+class HydrationBugFixTest extends TestCase
+{
+    public function testForeignKeyFieldDehydration()
+    {
+        // Create a test model that simulates the bug scenario
+        $testModel = new class extends OdooModel {
+            #[Field, Key]
+            public int|array $journal_id;
+            
+            #[Field('partner_id'), Key]
+            public int $partner_id;
+            
+            #[Field]
+            public ?string $name = null;
+            
+            #[HasMany(TestAccountMoveLine::class, 'line_ids')]
+            public array|\ArrayAccess $lines;
+        };
+        
+        // Set up test data that mimics the bug scenario
+        $testModel->journal_id = [1, "Customer invoices"]; // Array format from Odoo
+        $testModel->partner_id = 683;
+        $testModel->name = "Test Invoice";
+        
+        // Create a LazyHasMany that hasn't been loaded (simulating unmodified relationships)
+        $testModel->lines = new LazyHasMany(TestAccountMoveLine::class, 'read', [[1, 2, 3]]);
+        
+        // Dehydrate the model
+        $dehydrated = $testModel->dehydrate($testModel);
+        
+        // Assert that journal_id is converted to integer (not array)
+        $this->assertEquals(1, $dehydrated->journal_id);
+        $this->assertIsInt($dehydrated->journal_id);
+        
+        // Assert that partner_id remains as integer
+        $this->assertEquals(683, $dehydrated->partner_id);
+        $this->assertIsInt($dehydrated->partner_id);
+        
+        // Assert that name is preserved
+        $this->assertEquals("Test Invoice", $dehydrated->name);
+        
+        // Assert that unloaded LazyHasMany relationships are NOT included in dehydration
+        $this->assertFalse(property_exists($dehydrated, 'line_ids'));
+    }
+    
+    public function testLoadedRelationshipDehydration()
+    {
+        // Create a test model with loaded relationships
+        $testModel = new class extends OdooModel {
+            #[Field, Key]
+            public int|array $journal_id;
+            
+            #[HasMany(TestAccountMoveLine::class, 'line_ids')]
+            public array|\ArrayAccess $lines;
+        };
+        
+        // Create test line items with foreign key arrays
+        $line1 = new TestAccountMoveLine();
+        $line1->id = 1;
+        $line1->account_id = [316, "800100 Omzet NL handelsgoederen 1"];
+        $line1->partner_id = [683, "Test Partner"];
+        $line1->name = "Test Product 1";
+        
+        $line2 = new TestAccountMoveLine();
+        $line2->id = 2;
+        $line2->account_id = [73, "110000 Debiteuren"];
+        $line2->partner_id = [683, "Test Partner"];
+        $line2->name = "Test Product 2";
+        
+        $testModel->journal_id = [1, "Customer invoices"];
+        $testModel->lines = [$line1, $line2];
+        
+        // Dehydrate the model
+        $dehydrated = $testModel->dehydrate($testModel);
+        
+        // Assert that journal_id is converted to integer
+        $this->assertEquals(1, $dehydrated->journal_id);
+        
+        // Assert that line_ids contains proper update commands
+        $this->assertIsArray($dehydrated->line_ids);
+        $this->assertCount(2, $dehydrated->line_ids);
+        
+        // Check that each line command has proper structure [1, id, data]
+        foreach ($dehydrated->line_ids as $command) {
+            $this->assertIsArray($command);
+            $this->assertCount(3, $command);
+            $this->assertEquals(1, $command[0]); // Update command
+            $this->assertIsInt($command[1]); // Line ID
+            $this->assertIsObject($command[2]); // Line data
+            
+            // Assert that foreign key fields in the line data are integers
+            $lineData = $command[2];
+            $this->assertIsInt($lineData->account_id);
+            $this->assertIsInt($lineData->partner_id);
+        }
+    }
+    
+    public function testEmptyRelationshipDehydration()
+    {
+        $testModel = new class extends OdooModel {
+            #[HasMany(TestAccountMoveLine::class, 'line_ids')]
+            public ?array $lines = null;
+        };
+        
+        $testModel->lines = null;
+        
+        $dehydrated = $testModel->dehydrate($testModel);
+        
+        // Assert that null relationships are not included
+        $this->assertFalse(property_exists($dehydrated, 'line_ids'));
+    }
+}
+
+// Test model for the line items
+#[Model('account.move.line')]
+class TestAccountMoveLine extends OdooModel
+{
+    #[Field, Key]
+    public int|array $account_id;
+
+    #[Field, Key]
+    public int|array $partner_id;
+
+    #[Field]
+    public string $name;
+}

--- a/tests/OdooTest.php
+++ b/tests/OdooTest.php
@@ -307,7 +307,7 @@ class OdooTest extends TestCase
                 return [
                     // 1.Parameter = Domain
                     [
-                        ['is_company', '=', true]
+                        ['is_company', '=', false]
                     ]
                 ];
             }
@@ -323,7 +323,7 @@ class OdooTest extends TestCase
     public function testCallCustomMethodOverlay(){
         $ids = $this->odoo->executeKw('res.partner', 'search', [
             [
-                ['is_company', '=', true]
+                ['is_company', '=', false]
             ]
         ], new Options([
             'limit' => 3
@@ -360,34 +360,34 @@ class OdooTest extends TestCase
     public function testAggregate()
     {
 
-        $projectId = $this->odoo->model('project.project')
+        $orderId = $this->odoo->model('sale.order')
             ->create([
                 'name' => 'Aggregate Stuff',
-                'allow_timesheets' => true
+                'partner_id' => 1
             ]);
 
-        $time1 = $this->odoo->model('account.analytic.line')
+        $time1 = $this->odoo->model('sale.order.line')
             ->create([
-                'project_id' => $projectId,
-                'date' => date('Y-m-d'),
-                'unit_amount' => 3
+                'order_id' => $orderId,
+                'product_id' => 1,
+                'product_uom_qty' => 3
             ]);
 
-        $time2 = $this->odoo->model('account.analytic.line')
+        $time2 = $this->odoo->model('sale.order.line')
             ->create([
-                'project_id' => $projectId,
-                'date' => date('Y-m-d'),
-                'unit_amount' => 5
+                'order_id' => $orderId,
+                'product_id' => 1,
+                'product_uom_qty' => 5
             ]);
 
-        $response = $this->odoo->model('account.analytic.line')
-            ->where('project_id', '=', $projectId)
-            ->groupBy(['project_id'])
-            ->fields(['unit_amount:sum']) // Aggregation see: https://www.odoo.com/documentation/14.0/developer/reference/addons/orm.html#odoo.models.Model.read_group
+        $response = $this->odoo->model('sale.order.line')
+            ->where('order_id', '=', $orderId)
+            ->groupBy(['order_id'])
+            ->fields(['product_uom_qty:sum']) // Aggregation see: https://www.odoo.com/documentation/14.0/developer/reference/addons/orm.html#odoo.models.Model.read_group
             ->get();
 
-        $this->assertEquals($response[0]->project_id[0], $projectId);
-        $this->assertEquals($response[0]->unit_amount, 8);
+        $this->assertEquals($response[0]->order_id[0], $orderId);
+        $this->assertEquals($response[0]->product_uom_qty, 8);
 
     }
 


### PR DESCRIPTION
…sure_one() errors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes dehydration of foreign key fields that come as [id, name] arrays by sending only the ID, preventing Odoo ensure_one() errors. Also skips emitting relation commands for unloaded collections.

- **Bug Fixes**
  - Convert Key/BelongsTo fields from [id, name] to id during dehydrate, including nested related models via a safe dehydrateRelatedModel helper.
  - Skip dehydrating LazyHasMany relations that aren’t loaded; don’t include line_ids unless there are commands.
  - Only attach relation command arrays when non-empty.

- **Tests**
  - Added HydrationBugFixTest covering FK dehydration, loaded relation updates, and null relations.
  - Updated OdooTest fixtures for search and aggregation scenarios.

<!-- End of auto-generated description by cubic. -->

